### PR TITLE
feat: add `waitWindowLoad` function

### DIFF
--- a/src/modules/dom/index.ts
+++ b/src/modules/dom/index.ts
@@ -22,3 +22,5 @@ export type {
   MouseMovingEventCallback,
   MouseMovingEvents,
 } from './mouse-moving';
+
+export { default as waitWindowLoad } from './wait-window-load';

--- a/src/modules/dom/wait-window-load.ts
+++ b/src/modules/dom/wait-window-load.ts
@@ -1,0 +1,15 @@
+/**
+ * wait window load
+ * @returns {Promise} void Promise
+ */
+export default function waitWindowLoad(): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (typeof document !== 'undefined' && document.readyState === 'complete') {
+      resolve();
+    } else if (typeof window !== 'undefined') {
+      window.addEventListener('load', () => resolve());
+    } else {
+      reject();
+    }
+  });
+}


### PR DESCRIPTION
add `waitWindowLoad` function


میتونست کالبک فانکشن بگیره بجای پرامیس ولی خب پرامیس ترجیه دادم. نیازی بود تغییر بدم شبیه هوک های ویو باشه
```ts
onWindowLoaded(cb: fn => viold)
```