### PR TITLE
fix: disabled scrollSnap onscroll

### DIFF
--- a/src/modules/dom/mouse-moving.ts
+++ b/src/modules/dom/mouse-moving.ts
@@ -1,5 +1,5 @@
 import scrollSnap from './scroll-snap';
-import { delay, createThrottle, createDebounce } from '../helpers';
+import { delay, createThrottle } from '../helpers';
 
 export interface MouseMovingOptions {
   snap: boolean;
@@ -135,15 +135,10 @@ export default class MouseMoving {
   }
 
   private throttleScrollHandler = createThrottle(this.scroll.bind(this));
-  private debouncSnapHandler = createDebounce(this.snap.bind(this), 250);
 
   private scroll() {
     this.scrollX = this.el.scrollLeft;
     this.events.update?.(this.scrollX);
-
-    if (this.options.snap && !this.isOnMoving) {
-      this.debouncSnapHandler();
-    }
   }
 
   private snap() {


### PR DESCRIPTION
سلام صالح جان. این مورد بخاطر مشکلاتی که توی موبایل پیش میاره الان غیرفعال شد.
اینو زمانی اضافه کرده بودیم که اسکرول کردن لیست افقی با تاچ لپتاپ که انجام میشد سینک نبود. فقط در اون حالت 
snap
 غیر فعال میشه تا عملکرد موبایل که مهمتر از این موضوع هست به هم نخوره.
 ما از اول هم اسنپ رو. در موبایل نمیخواستیم